### PR TITLE
Fix typo in git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Treesitter Grammar needs to be installed like that:
 
 ```
   (setq treesit-language-source-alist
-   '((terraform . ("https://github.com/MichaHoffmann/tree-sitter-hcl"  "`main"  "dialects/terraform/src"))))
+   '((terraform . ("https://github.com/MichaHoffmann/tree-sitter-hcl"  "main"  "dialects/terraform/src"))))
 ```
 
 Don´t forget to to run ```(treesit-install-language-grammar)```


### PR DESCRIPTION
Following the instructions I ran into

```
⛔ Warning (treesit): Error encountered when installing language grammar: (treesit-error Command: git clone https://github.com/MichaHoffmann/tree-sitter-hcl --depth 1 --quiet -b `main /var/folders/21/6tx87v9d5_51h32vb0980fs00000gn/T/treesit-workdirSEPNml/repo Error output: warning: Could not find remote branch `main to clone.
fatal: Remote branch `main not found in upstream origin
```

I could easily fix this by changing the branch to remove the backtick.